### PR TITLE
Add SetProtocols method to peerstore

### DIFF
--- a/peerstore.go
+++ b/peerstore.go
@@ -46,6 +46,7 @@ type Peerstore interface {
 
 	GetProtocols(peer.ID) ([]string, error)
 	AddProtocols(peer.ID, ...string) error
+	SetProtocols(peer.ID, ...string) error
 	SupportsProtocols(peer.ID, ...string) ([]string, error)
 }
 
@@ -233,6 +234,18 @@ func (ps *peerstore) PeerInfo(p peer.ID) PeerInfo {
 		ID:    p,
 		Addrs: ps.AddrManager.Addrs(p),
 	}
+}
+
+func (ps *peerstore) SetProtocols(p peer.ID, protos ...string) error {
+	ps.protolock.Lock()
+	defer ps.protolock.Unlock()
+
+	protomap := make(map[string]struct{})
+	for _, proto := range protos {
+		protomap[proto] = struct{}{}
+	}
+
+	return ps.Put(p, "protocols", protomap)
 }
 
 func (ps *peerstore) AddProtocols(p peer.ID, protos ...string) error {

--- a/peerstore_test.go
+++ b/peerstore_test.go
@@ -220,6 +220,20 @@ func TestPeerstoreProtoStore(t *testing.T) {
 	if supported[0] != "a" || supported[1] != "b" {
 		t.Fatal("got wrong supported array: ", supported)
 	}
+
+	err = ps.SetProtocols(p1, "other")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	supported, err = ps.SupportsProtocols(p1, "q", "w", "a", "y", "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(supported) != 0 {
+		t.Fatal("none of those protocols should have been supported")
+	}
 }
 
 func TestBasicPeerstore(t *testing.T) {


### PR DESCRIPTION
This allows us to overwrite known protocols and remove potentially
unwanted ones during a full knowledge update. The current AddProtocol
just appends to the existing set.