### PR TITLE
more effectively free memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 
 sudo: false
 

--- a/addr_manager.go
+++ b/addr_manager.go
@@ -267,7 +267,7 @@ func (mgr *AddrManager) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Mul
 	mgr.addrSubs[p] = append(mgr.addrSubs[p], sub)
 
 	baseaddrset := mgr.addrs[p]
-	var initial []ma.Multiaddr
+	initial := make([]ma.Multiaddr, 0, len(baseaddrset))
 	for _, a := range baseaddrset {
 		initial = append(initial, a.Addr)
 	}
@@ -277,7 +277,7 @@ func (mgr *AddrManager) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Mul
 	go func(buffer []ma.Multiaddr) {
 		defer close(out)
 
-		sent := make(map[string]bool)
+		sent := make(map[string]bool, len(buffer))
 		var outch chan ma.Multiaddr
 
 		for _, a := range buffer {

--- a/addr_manager.go
+++ b/addr_manager.go
@@ -281,7 +281,7 @@ func (mgr *AddrManager) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Mul
 		var outch chan ma.Multiaddr
 
 		for _, a := range buffer {
-			sent[a.String()] = true
+			sent[string(a.Bytes())] = true
 		}
 
 		var next ma.Multiaddr
@@ -302,11 +302,11 @@ func (mgr *AddrManager) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Mul
 					next = nil
 				}
 			case naddr := <-sub.pubch:
-				if sent[naddr.String()] {
+				if sent[string(naddr.Bytes())] {
 					continue
 				}
 
-				sent[naddr.String()] = true
+				sent[string(naddr.Bytes())] = true
 				if next == nil {
 					next = naddr
 					outch = out

--- a/peerstore_test.go
+++ b/peerstore_test.go
@@ -54,6 +54,10 @@ func TestAddrStream(t *testing.T) {
 		}
 	}
 
+	// start a second stream
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	addrch2 := ps.AddrStream(ctx2, pid)
+
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -83,9 +87,17 @@ func TestAddrStream(t *testing.T) {
 		}
 	}
 
-	// now cancel it, and add a few more addresses it doesnt hang afterwards
+	// now cancel it
 	cancel()
 
+	// now check the *second* subscription. We should see 80 addresses.
+	for i := 0; i < 80; i++ {
+		<-addrch2
+	}
+
+	cancel2()
+
+	// and add a few more addresses it doesnt hang afterwards
 	for _, a := range addrs[80:] {
 		ps.AddAddr(pid, a, time.Hour)
 	}


### PR DESCRIPTION
* Completely free memory related to subscriptions when all subscribers go away.
* Completely free peer address records when they all expire.
* Don't copy the *entire* subscription array when unsubscribing from a peer
  address stream.