### PR TITLE
Datastore-backed implementations of KeyBook and PeerMetadata

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -68,6 +68,13 @@ type Peerstore interface {
 	Peers() peer.IDSlice
 }
 
+// PeerMetadata can handle values of any type. Serializing values is
+// up to the implementation. Dynamic type introspection may not be
+// supported, in which case explicitly enlisting types in the
+// serializer may be required.
+//
+// Refer to the docs of the underlying implementation for more
+// information.
 type PeerMetadata interface {
 	// Get/Put is a simple registry for other peer-related key/value pairs.
 	// if we find something we use often, it should become its own set of

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
       "hash": "QmQjMHF8ptRgx4E57UFMiT4YM6kqaJeYxZ1MCDX23aw4rK",
       "name": "golang-lru",
       "version": "2017.10.18"
+    },
+    {
+      "author": "Stebalien",
+      "hash": "QmUQy76yspPa3fRyY3GzXFTg9n8JVwFru6ue3KFRt4MeTw",
+      "name": "go-buffer-pool",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.4.0",

--- a/pstoreds/ds_test.go
+++ b/pstoreds/ds_test.go
@@ -143,6 +143,10 @@ func TestBadgerDsAddrBook(t *testing.T) {
 	})
 }
 
+func TestBadgerDsKeyBook(t *testing.T) {
+	pt.TestKeyBook(t, keyBookFactory(t, DefaultOpts()))
+}
+
 func BenchmarkBadgerDsPeerstore(b *testing.B) {
 	caching := DefaultOpts()
 	caching.CacheSize = 1024
@@ -159,15 +163,15 @@ func badgerStore(t testing.TB) (ds.TxnDatastore, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ds, err := badger.NewDatastore(dataPath, nil)
+	store, err := badger.NewDatastore(dataPath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	closer := func() {
-		ds.Close()
+		store.Close()
 		os.RemoveAll(dataPath)
 	}
-	return ds, closer
+	return store, closer
 }
 
 func peerstoreFactory(tb testing.TB, opts Options) pt.PeerstoreFactory {
@@ -193,5 +197,13 @@ func addressBookFactory(tb testing.TB, opts Options) pt.AddrBookFactory {
 		}
 
 		return ab, closeFunc
+	}
+}
+
+func keyBookFactory(tb testing.TB, opts Options) pt.KeyBookFactory {
+	return func() (pstore.KeyBook, func()) {
+		store, closeFunc := badgerStore(tb)
+		kb, _ := NewKeyBook(context.Background(), store, opts)
+		return kb, closeFunc
 	}
 }

--- a/pstoreds/keybook.go
+++ b/pstoreds/keybook.go
@@ -1,0 +1,128 @@
+package pstoreds
+
+import (
+	"context"
+	"errors"
+
+	ds "github.com/ipfs/go-datastore"
+	query "github.com/ipfs/go-datastore/query"
+
+	ic "github.com/libp2p/go-libp2p-crypto"
+	peer "github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+)
+
+// Public and private keys are stored under the following db key pattern:
+// /peers/keys/<b58 of peer id>/{pub, priv}
+var (
+	kbBase     = ds.NewKey("/peers/keys")
+	pubSuffix  = ds.NewKey("/pub")
+	privSuffix = ds.NewKey("/priv")
+)
+
+type dsKeyBook struct {
+	ds ds.TxnDatastore
+}
+
+var _ pstore.KeyBook = (*dsKeyBook)(nil)
+
+func NewKeyBook(_ context.Context, store ds.TxnDatastore, _ Options) (pstore.KeyBook, error) {
+	return &dsKeyBook{store}, nil
+}
+
+func (kb *dsKeyBook) PubKey(p peer.ID) ic.PubKey {
+	key := kbBase.ChildString(peer.IDB58Encode(p)).Child(pubSuffix)
+
+	var pk ic.PubKey
+	if value, err := kb.ds.Get(key); err == nil {
+		pk, err = ic.UnmarshalPublicKey(value)
+		if err != nil {
+			log.Errorf("error when unmarshalling pubkey from datastore for peer %s: %s\n", p.Pretty(), err)
+		}
+	} else if err == ds.ErrNotFound {
+		pk, err = p.ExtractPublicKey()
+		if err != nil {
+			log.Errorf("error when extracting pubkey from peer ID for peer %s: %s\n", p.Pretty(), err)
+			return nil
+		}
+		pkb, err := pk.Bytes()
+		if err != nil {
+			log.Errorf("error when turning extracted pubkey into bytes for peer %s: %s\n", p.Pretty(), err)
+			return nil
+		}
+		err = kb.ds.Put(key, pkb)
+		if err != nil {
+			log.Errorf("error when adding extracted pubkey to peerstore for peer %s: %s\n", p.Pretty(), err)
+			return nil
+		}
+	} else {
+		log.Errorf("error when fetching pubkey from datastore for peer %s: %s\n", p.Pretty(), err)
+	}
+
+	return pk
+}
+
+func (kb *dsKeyBook) AddPubKey(p peer.ID, pk ic.PubKey) error {
+	// check it's correct.
+	if !p.MatchesPublicKey(pk) {
+		return errors.New("peer ID does not match public key")
+	}
+
+	key := kbBase.ChildString(peer.IDB58Encode(p)).Child(pubSuffix)
+	val, err := pk.Bytes()
+	if err != nil {
+		log.Errorf("error while converting pubkey byte string for peer %s: %s\n", p.Pretty(), err)
+		return err
+	}
+	err = kb.ds.Put(key, val)
+	if err != nil {
+		log.Errorf("error while updating pubkey in datastore for peer %s: %s\n", p.Pretty(), err)
+	}
+	return err
+}
+
+func (kb *dsKeyBook) PrivKey(p peer.ID) ic.PrivKey {
+	key := kbBase.ChildString(peer.IDB58Encode(p)).Child(privSuffix)
+	value, err := kb.ds.Get(key)
+	if err != nil {
+		log.Errorf("error while fetching privkey from datastore for peer %s: %s\n", p.Pretty(), err)
+		return nil
+	}
+	sk, err := ic.UnmarshalPrivateKey(value)
+	if err != nil {
+		return nil
+	}
+	return sk
+}
+
+func (kb *dsKeyBook) AddPrivKey(p peer.ID, sk ic.PrivKey) error {
+	if sk == nil {
+		return errors.New("private key is nil")
+	}
+	// check it's correct.
+	if !p.MatchesPrivateKey(sk) {
+		return errors.New("peer ID does not match private key")
+	}
+
+	key := kbBase.ChildString(peer.IDB58Encode(p)).Child(privSuffix)
+	val, err := sk.Bytes()
+	if err != nil {
+		log.Errorf("error while converting privkey byte string for peer %s: %s\n", p.Pretty(), err)
+		return err
+	}
+	err = kb.ds.Put(key, val)
+	if err != nil {
+		log.Errorf("error while updating privkey in datastore for peer %s: %s\n", p.Pretty(), err)
+	}
+	return err
+}
+
+func (kb *dsKeyBook) PeersWithKeys() peer.IDSlice {
+	ids, err := uniquePeerIds(kb.ds, kbBase, func(result query.Result) string {
+		return ds.RawKey(result.Key).Parent().Name()
+	})
+	if err != nil {
+		log.Errorf("error while retrieving peers with keys: %v", err)
+	}
+	return ids
+}

--- a/pstoreds/metadata.go
+++ b/pstoreds/metadata.go
@@ -1,0 +1,65 @@
+package pstoreds
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+
+	ds "github.com/ipfs/go-datastore"
+
+	pool "github.com/libp2p/go-buffer-pool"
+	peer "github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+)
+
+// Metadata is stored under the following db key pattern:
+// /peers/metadata/<b58 peer id>/<key>
+var pmBase = ds.NewKey("/peers/metadata")
+
+type dsPeerMetadata struct {
+	ds ds.Datastore
+}
+
+var _ pstore.PeerMetadata = (*dsPeerMetadata)(nil)
+
+func init() {
+	// Gob registers basic types by default.
+	//
+	// Register complex types used by the peerstore itself.
+	gob.Register(make(map[string]struct{}))
+}
+
+// NewPeerMetadata creates a metadata store backed by a persistent db. It uses gob for serialisation.
+//
+// See `init()` to learn which types are registered by default. Modules wishing to store
+// values of other types will need to `gob.Register()` them explicitly, or else callers
+// will receive runtime errors.
+func NewPeerMetadata(_ context.Context, store ds.Datastore, _ Options) (pstore.PeerMetadata, error) {
+	return &dsPeerMetadata{store}, nil
+}
+
+func (pm *dsPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
+	k := pmBase.ChildString(peer.IDB58Encode(p)).ChildString(key)
+	value, err := pm.ds.Get(k)
+	if err != nil {
+		if err == ds.ErrNotFound {
+			err = pstore.ErrNotFound
+		}
+		return nil, err
+	}
+
+	var res interface{}
+	if err := gob.NewDecoder(bytes.NewReader(value)).Decode(&res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (pm *dsPeerMetadata) Put(p peer.ID, key string, val interface{}) error {
+	k := pmBase.ChildString(peer.IDB58Encode(p)).ChildString(key)
+	var buf pool.Buffer
+	if err := gob.NewEncoder(&buf).Encode(&val); err != nil {
+		return err
+	}
+	return pm.ds.Put(k, buf.Bytes())
+}

--- a/pstoreds/peerstore.go
+++ b/pstoreds/peerstore.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/query"
-	"github.com/libp2p/go-libp2p-peer"
+	query "github.com/ipfs/go-datastore/query"
 
+	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 )
 

--- a/pstoreds/peerstore.go
+++ b/pstoreds/peerstore.go
@@ -67,13 +67,13 @@ func uniquePeerIds(ds ds.TxnDatastore, prefix ds.Key, extractor func(result quer
 
 	txn, err := ds.NewTransaction(true)
 	if err != nil {
-		return peer.IDSlice{}, err
+		return nil, err
 	}
 	defer txn.Discard()
 
 	if results, err = txn.Query(q); err != nil {
 		log.Error(err)
-		return peer.IDSlice{}, err
+		return nil, err
 	}
 
 	defer results.Close()
@@ -82,8 +82,6 @@ func uniquePeerIds(ds ds.TxnDatastore, prefix ds.Key, extractor func(result quer
 	for result := range results.Next() {
 		k := extractor(result)
 		idset[k] = struct{}{}
-		//key := ds.RawKey(result.Key)
-		//idset[key.Parent().Name()] = struct{}{}
 	}
 
 	if len(idset) == 0 {

--- a/pstoremem/metadata.go
+++ b/pstoremem/metadata.go
@@ -10,10 +10,11 @@ import (
 type memoryPeerMetadata struct {
 	// store other data, like versions
 	//ds ds.ThreadSafeDatastore
-	// TODO: use a datastore for this
 	ds     map[string]interface{}
 	dslock sync.Mutex
 }
+
+var _ pstore.PeerMetadata = (*memoryPeerMetadata)(nil)
 
 func NewPeerMetadata() pstore.PeerMetadata {
 	return &memoryPeerMetadata{


### PR DESCRIPTION
All pretty standard, except that the `PeerMetadata` accepts values of wildcard type (`interface{}`), which now need to be serialised and deserialised. 

Took the simple path and used gob, which requires registering non-basic types beforehand, like `map[string]struct{}`, used by the `*Protocol()` methods on `Peerstore`.

However, given the public interface, it's possible for callers to use custom types (e.g. storing custom structs as metadata), which will need to be enlisted with the serialiser. I considered different options:

1. Dynamically registering types on `Put()` and keeping a type cache to avoid duplicate registrations (even if they are harmless), but this doesn't work on restart, as the user may `Get()` values for a type that hasn't been registered via `Put()` yet.
2. Adding a configuration attribute on `Options`: `SupportedTypes: []interface{}`, but the peerstore is likely initialised before other modules that may need to add custom types.
3. Adding a new method on the interface `RegisterType()`.
4. Informing the user in the docs that they need to register custom types manually.

I went with 4 for now, but I'm happy to switch to 3 if it's deemed necessary.

---

Also, I segregated storage keys per component:

* KeyBook pattern: `/peers/keys/<b58 peerid>/{pub,priv}`
* AddrBook pattern: `/peers/addrs/<b58 peerid>/<hash maddr>`
* PeerMetadata pattern: `/peers/metadata/<b58 peerid>/<key>`

The natural (hierarchical) pattern would've been like:
* `/peer:<b58 peerid>/key:{pub,priv}`
* `/peer:<b58 peerid>/addr:<hash maddr>`
* `/peer:<b58 peerid>/meta:<key>`

But it makes range queries inefficient.