### PR TITLE
reduce allocations and garbage collect the in-memory peerstore

### DIFF
--- a/pstoremem/addr_book.go
+++ b/pstoremem/addr_book.go
@@ -45,6 +45,7 @@ func NewAddrBook() pstore.AddrBook {
 	}
 }
 
+// gc garbage collects the in-memory address book. The caller *must* hold the addrmu lock.
 func (mab *memoryAddrBook) gc() {
 	now := time.Now()
 	if !now.After(mab.nextGC) {


### PR DESCRIPTION
1. Revert to the memory heavy, allocation light in-memory representation. We switched to arrays to save memory but, unfortunately, that started killing us on allocations.
2. Add a once-per-hour GC cycle. We GC when we *read* a peer's addresses but we don't do that very often.

Now, there *are* better ways to GC and we should probably use them. However, this is probably a decent stop-gap.