### PR TITLE
update to match new ExtractPublicKey API

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbNepETomvmXfz1X5pHNFD2QuPqnqi47dTd94QJWSorQ3",
+      "hash": "QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB",
       "name": "go-libp2p-peer",
-      "version": "2.3.8"
+      "version": "2.4.0"
     },
     {
       "author": "multiformats",

--- a/pstoreds/keybook.go
+++ b/pstoreds/keybook.go
@@ -43,7 +43,11 @@ func (kb *dsKeyBook) PubKey(p peer.ID) ic.PubKey {
 		}
 	} else if err == ds.ErrNotFound {
 		pk, err = p.ExtractPublicKey()
-		if err != nil {
+		switch err {
+		case nil:
+		case peer.ErrNoPublicKey:
+			return nil
+		default:
 			log.Errorf("error when extracting pubkey from peer ID for peer %s: %s\n", p.Pretty(), err)
 			return nil
 		}

--- a/pstoremem/keybook.go
+++ b/pstoremem/keybook.go
@@ -49,7 +49,7 @@ func (mkb *memoryKeyBook) PubKey(p peer.ID) ic.PubKey {
 		return pk
 	}
 	pk, err := p.ExtractPublicKey()
-	if err == nil && pk != nil {
+	if err == nil {
 		mkb.Lock()
 		mkb.pks[p] = pk
 		mkb.Unlock()

--- a/test/keybook_suite.go
+++ b/test/keybook_suite.go
@@ -50,6 +50,10 @@ func testKeybookPrivKey(kb pstore.KeyBook) func(t *testing.T) {
 			t.Error(err)
 		}
 
+		if res := kb.PrivKey(id); res != nil {
+			t.Error("retrieving private key should have failed")
+		}
+
 		err = kb.AddPrivKey(id, priv)
 		if err != nil {
 			t.Error(err)
@@ -79,6 +83,10 @@ func testKeyBookPubKey(kb pstore.KeyBook) func(t *testing.T) {
 		id, err := peer.IDFromPublicKey(pub)
 		if err != nil {
 			t.Error(err)
+		}
+
+		if res := kb.PubKey(id); res != nil {
+			t.Error("retrieving public key should have failed")
 		}
 
 		err = kb.AddPubKey(id, pub)


### PR DESCRIPTION
This is a "more correct" API and we might as well fix this before it becomes used all over the place. The new API returns ErrNoPublicKey when there is no inlined key.

This *also* fixes a bug where the datastore-backed keystore would panic if `ExtractPublicKey` returned `nil, nil`.