### PR TITLE
fix the inline key test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 language: go
 
 go:
-    - 1.9.x
+    - 1.11.x
 
 install:
   - make deps

--- a/test/keybook_suite.go
+++ b/test/keybook_suite.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"testing"
 
+	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pt "github.com/libp2p/go-libp2p-peer/test"
 
@@ -144,7 +145,7 @@ func testInlinedPubKeyAddedOnRetrieve(kb pstore.KeyBook) func(t *testing.T) {
 		}
 
 		// Key small enough for inlining.
-		_, pub, err := pt.RandTestKeyPair(32)
+		_, pub, err := ic.GenerateKeyPair(ic.Ed25519, 256)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
RandTestKeyPair uses RSA keys but we now forbid any RSA key under 512 bits.