### PR TITLE
PeerInfo UnMarshal Error #393

### DIFF
--- a/peerinfo.go
+++ b/peerinfo.go
@@ -70,14 +70,14 @@ func InfoToP2pAddrs(pi *PeerInfo) ([]ma.Multiaddr, error) {
 	return addrs, nil
 }
 
-func (pi *PeerInfo) Loggable() map[string]interface{} {
+func (pi PeerInfo) Loggable() map[string]interface{} {
 	return map[string]interface{}{
 		"peerID": pi.ID.Pretty(),
 		"addrs":  pi.Addrs,
 	}
 }
 
-func (pi *PeerInfo) MarshalJSON() ([]byte, error) {
+func (pi PeerInfo) MarshalJSON() ([]byte, error) {
 	out := make(map[string]interface{})
 	out["ID"] = pi.ID.Pretty()
 	var addrs []string
@@ -88,7 +88,7 @@ func (pi *PeerInfo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-func (pi *PeerInfo) UnmarshalJSON(b []byte) error {
+func (pi PeerInfo) UnmarshalJSON(b []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(b, &data)
 	if err != nil {

--- a/peerinfo.go
+++ b/peerinfo.go
@@ -70,7 +70,7 @@ func InfoToP2pAddrs(pi *PeerInfo) ([]ma.Multiaddr, error) {
 	return addrs, nil
 }
 
-func (pi PeerInfo) Loggable() map[string]interface{} {
+func (pi *PeerInfo) Loggable() map[string]interface{} {
 	return map[string]interface{}{
 		"peerID": pi.ID.Pretty(),
 		"addrs":  pi.Addrs,
@@ -88,7 +88,7 @@ func (pi PeerInfo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-func (pi PeerInfo) UnmarshalJSON(b []byte) error {
+func (pi *PeerInfo) UnmarshalJSON(b []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(b, &data)
 	if err != nil {

--- a/peerinfo_test.go
+++ b/peerinfo_test.go
@@ -1,6 +1,7 @@
 package peerstore
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/libp2p/go-libp2p-peer"
@@ -36,6 +37,88 @@ func TestPeerInfoMarshal(t *testing.T) {
 
 	pi2 := new(PeerInfo)
 	if err := pi2.UnmarshalJSON(data); err != nil {
+		t.Fatal(err)
+	}
+
+	if pi2.ID != pi.ID {
+		t.Fatal("ids didnt match after marshal")
+	}
+
+	if !pi.Addrs[0].Equal(pi2.Addrs[0]) {
+		t.Fatal("wrong addrs")
+	}
+
+	if !pi.Addrs[1].Equal(pi2.Addrs[1]) {
+		t.Fatal("wrong addrs")
+	}
+
+	lgbl := pi2.Loggable()
+	if lgbl["peerID"] != id.Pretty() {
+		t.Fatal("loggables gave wrong peerID output")
+	}
+}
+
+func TestPeerInfoMarshalWithPointer(t *testing.T) {
+	a := mustAddr(t, "/ip4/1.2.3.4/tcp/4536")
+	b := mustAddr(t, "/ip4/1.2.3.8/udp/7777")
+	id, err := peer.IDB58Decode("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pi := PeerInfo{
+		ID:    id,
+		Addrs: []ma.Multiaddr{a, b},
+	}
+
+	data, err := json.Marshal(&pi)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pi2 := new(PeerInfo)
+	if err := json.Unmarshal(data, pi2); err != nil {
+		t.Fatal(err)
+	}
+
+	if pi2.ID != pi.ID {
+		t.Fatal("ids didnt match after marshal")
+	}
+
+	if !pi.Addrs[0].Equal(pi2.Addrs[0]) {
+		t.Fatal("wrong addrs")
+	}
+
+	if !pi.Addrs[1].Equal(pi2.Addrs[1]) {
+		t.Fatal("wrong addrs")
+	}
+
+	lgbl := pi2.Loggable()
+	if lgbl["peerID"] != id.Pretty() {
+		t.Fatal("loggables gave wrong peerID output")
+	}
+}
+
+func TestPeerInfoMarshalWithValue(t *testing.T) {
+	a := mustAddr(t, "/ip4/1.2.3.4/tcp/4536")
+	b := mustAddr(t, "/ip4/1.2.3.8/udp/7777")
+	id, err := peer.IDB58Decode("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pi := PeerInfo{
+		ID:    id,
+		Addrs: []ma.Multiaddr{a, b},
+	}
+
+	data, err := json.Marshal(pi)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pi2 := new(PeerInfo)
+	if err := json.Unmarshal(data, pi2); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The issue is [here](https://github.com/libp2p/go-libp2p/issues/393). Now `json.Marshal` can take value or pointer.