### PR TITLE
README: Update contributing guideline linkrot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 ### Want to hack on IPFS?
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 
 ## License
 MIT


### PR DESCRIPTION
Looks like the full path is case-sensitive.