### PR TITLE
Implement fmt.Stringer for PeerInfo

### DIFF
--- a/peerinfo.go
+++ b/peerinfo.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -16,6 +16,12 @@ import (
 type PeerInfo struct {
 	ID    peer.ID
 	Addrs []ma.Multiaddr
+}
+
+var _ fmt.Stringer = PeerInfo{}
+
+func (pi PeerInfo) String() string {
+	return fmt.Sprintf("{%v: %v}", pi.ID, pi.Addrs)
 }
 
 var ErrInvalidAddr = fmt.Errorf("invalid p2p multiaddr")


### PR DESCRIPTION
Currently when logged, this type spews raw binary from the ID field (which causes havoc on terminals and confuses text consumers). The goal is similar to https://github.com/libp2p/go-libp2p-peer/pull/47.