### PR TITLE
keep temp addresses for 2 minutes

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -19,7 +19,7 @@ var (
 	AddressTTL = time.Hour
 
 	// TempAddrTTL is the ttl used for a short lived address
-	TempAddrTTL = time.Second * 10
+	TempAddrTTL = time.Minute * 2
 
 	// ProviderAddrTTL is the TTL of an address we've received from a provider.
 	// This is also a temporary address, but lasts longer. After this expires,


### PR DESCRIPTION
Unfortunately, services like the DHT are slow enough that we can forget addresses before we successfully dial.