### PR TITLE
don't delete under the read lock

### DIFF
--- a/pstoremem/addr_book.go
+++ b/pstoremem/addr_book.go
@@ -75,6 +75,11 @@ func (mab *memoryAddrBook) background() {
 	}
 }
 
+func (mab *memoryAddrBook) Close() error {
+	mab.cancel()
+	return nil
+}
+
 // gc garbage collects the in-memory address book. The caller *must* hold the addrmu lock.
 func (mab *memoryAddrBook) gc() {
 	now := time.Now()

--- a/pstoremem/addr_book.go
+++ b/pstoremem/addr_book.go
@@ -188,11 +188,9 @@ func (mab *memoryAddrBook) Addrs(p peer.ID) []ma.Multiaddr {
 
 	now := time.Now()
 	good := make([]ma.Multiaddr, 0, len(amap))
-	for k, m := range amap {
+	for _, m := range amap {
 		if !m.ExpiredBy(now) {
 			good = append(good, m.Addr)
-		} else {
-			delete(amap, k)
 		}
 	}
 


### PR DESCRIPTION
Fixes the panic in #75 and also reworks the gc logic to happen in the background with a periodic process.
Closes #75 