### PR TITLE
[BLOCKED] Deprecate the queue package, as it has been moved to go-libp2p-kad-dht

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,0 +1,4 @@
+// Deprecated: This package has been moved, please use:
+// github.com/libp2p/go-libp2p-kad-dht/queue
+
+package queue


### PR DESCRIPTION
Related to go-libp2p [#646](https://github.com/libp2p/go-libp2p/issues/646)

Deprecating instead of deleting, as there are many external codebases dependent on this package.

Blocked on merge of go-libp2p-kad-dht [#352](https://github.com/libp2p/go-libp2p-kad-dht/pull/352)