### PR TITLE
fix multiple TTL bugs

### DIFF
--- a/pstoreds/addr_book.go
+++ b/pstoreds/addr_book.go
@@ -347,11 +347,21 @@ Outer:
 		for _, have := range pr.Addrs {
 			if incoming.Equal(have.Addr) {
 				existed[i] = true
-				if mode == ttlExtend && have.Expiry > newExp {
-					// if we're only extending TTLs but the addr already has a longer one, we skip it.
-					continue Outer
+				switch mode {
+				case ttlOverride:
+					have.Ttl = int64(ttl)
+					have.Expiry = newExp
+				case ttlExtend:
+					if int64(ttl) > have.Ttl {
+						have.Ttl = int64(ttl)
+					}
+					if newExp > have.Expiry {
+						have.Expiry = newExp
+					}
+				default:
+					panic("BUG: unimplemented ttl mode")
 				}
-				have.Expiry = newExp
+
 				// we found the address, and addresses cannot be duplicate,
 				// so let's move on to the next.
 				continue Outer


### PR DESCRIPTION
The first fix independently extends the address expiration time and the address TTL:

By example:

* We have an address with a TTL of 4s that will expire in 1s.
* We update it with a TTL of 3s.

Before this change:

* We end up with an address with a TTL of 3s that will expire in 3s.

After this change:

* We end up with an address with a TTL of 4s that will expire in 3s.

---

The second fix prevents the in-memory addressbook from announcing existing addresses every time their TTLs get updated.

---

The third fix correctly updates TTLs for existing addresses in the on-disk addressbook.

This fixes https://github.com/libp2p/go-libp2p-identify/issues/2