### PR TITLE
fix two bugs in signed address handling

### DIFF
--- a/pstoreds/addr_book.go
+++ b/pstoreds/addr_book.go
@@ -278,8 +278,9 @@ func (ab *dsAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, ttl tim
 		return false, fmt.Errorf("signing key does not match PeerID in PeerRecord")
 	}
 
-	// ensure that the seq number from envelope is > any previously received seq no
-	if ab.latestPeerRecordSeq(rec.PeerID) >= rec.Seq {
+	// ensure that the seq number from envelope is >= any previously received seq no
+	// update when equal to extend the ttls
+	if ab.latestPeerRecordSeq(rec.PeerID) > rec.Seq {
 		return false, nil
 	}
 

--- a/pstoremem/addr_book.go
+++ b/pstoremem/addr_book.go
@@ -178,11 +178,11 @@ func (mab *memoryAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, tt
 		return false, fmt.Errorf("signing key does not match PeerID in PeerRecord")
 	}
 
-	// ensure seq is greater than last received
+	// ensure seq is greater than, or equal to, the last received
 	s := mab.segments.get(rec.PeerID)
 	s.Lock()
 	lastState, found := s.signedPeerRecords[rec.PeerID]
-	if found && lastState.Seq >= rec.Seq {
+	if found && lastState.Seq > rec.Seq {
 		s.Unlock()
 		return false, nil
 	}

--- a/pstoremem/addr_book.go
+++ b/pstoremem/addr_book.go
@@ -159,7 +159,7 @@ func (mab *memoryAddrBook) AddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Du
 	// if peerRec != nil {
 	// 	return
 	// }
-	mab.addAddrs(p, addrs, ttl, false)
+	mab.addAddrs(p, addrs, ttl)
 }
 
 // ConsumePeerRecord adds addresses from a signed peer.PeerRecord (contained in
@@ -181,34 +181,37 @@ func (mab *memoryAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, tt
 	// ensure seq is greater than, or equal to, the last received
 	s := mab.segments.get(rec.PeerID)
 	s.Lock()
+	defer s.Unlock()
 	lastState, found := s.signedPeerRecords[rec.PeerID]
 	if found && lastState.Seq > rec.Seq {
-		s.Unlock()
 		return false, nil
 	}
 	s.signedPeerRecords[rec.PeerID] = &peerRecordState{
 		Envelope: recordEnvelope,
 		Seq:      rec.Seq,
 	}
-	s.Unlock() // need to release the lock, since addAddrs will try to take it
-	mab.addAddrs(rec.PeerID, rec.Addrs, ttl, true)
+	mab.addAddrsUnlocked(s, rec.PeerID, rec.Addrs, ttl, true)
 	return true, nil
 }
 
-func (mab *memoryAddrBook) addAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration, signed bool) {
+func (mab *memoryAddrBook) addAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration) {
 	if err := p.Validate(); err != nil {
 		log.Warningf("tried to set addrs for invalid peer ID %s: %s", p, err)
-		return
-	}
-
-	// if ttl is zero, exit. nothing to do.
-	if ttl <= 0 {
 		return
 	}
 
 	s := mab.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
+
+	mab.addAddrsUnlocked(s, p, addrs, ttl, false)
+}
+
+func (mab *memoryAddrBook) addAddrsUnlocked(s *addrSegment, p peer.ID, addrs []ma.Multiaddr, ttl time.Duration, signed bool) {
+	// if ttl is zero, exit. nothing to do.
+	if ttl <= 0 {
+		return
+	}
 
 	amap, ok := s.addrs[p]
 	if !ok {


### PR DESCRIPTION
1. Previously, two calls to ConsumePeerRecord could interleave and cause us to keep _old_ addresses with a _new_ record. This has only been fixed in the in-memory peerstore.
2. Changes `ConsumePeerRecord` to accept peer records with sequence numbers equal to existing peer records. This lets us update the TTL. Otherwise, we'll never update the TTL for a peer's addresses until they create a new record.