### PR TITLE
fix: delete addrs when "updating" them to zero

### DIFF
--- a/test/addr_book_suite.go
+++ b/test/addr_book_suite.go
@@ -210,6 +210,18 @@ func testUpdateTTLs(m pstore.AddrBook) func(t *testing.T) {
 			m.UpdateAddrs(id, time.Hour, time.Minute)
 		})
 
+		t.Run("update to 0 clears addrs", func(t *testing.T) {
+			id := GeneratePeerIDs(1)[0]
+			addrs := GenerateAddrs(1)
+
+			// Shouldn't panic.
+			m.SetAddrs(id, addrs, time.Hour)
+			m.UpdateAddrs(id, time.Hour, 0)
+			if len(m.Addrs(id)) != 0 {
+				t.Error("expected no addresses")
+			}
+		})
+
 		t.Run("update ttls successfully", func(t *testing.T) {
 			ids := GeneratePeerIDs(2)
 			addrs1, addrs2 := GenerateAddrs(2), GenerateAddrs(2)


### PR DESCRIPTION
1. Fix expiration check to check "not before" instead of after. Otherwise, something that is expiring "now" won't count as expired. The datastore-backed peerstore already had the correct logic.
2. Short-circuit updating the TTL to 0 and just delete the records.

Note: this wasn't causing problems on Linux (likely due to monotonic clocks?) but was causing go-libp2p tests to fail reliably on Windows.