### PR TITLE
fix: set expiration to 0 when TTL is 0

### DIFF
--- a/pstoreds/ds_test.go
+++ b/pstoreds/ds_test.go
@@ -33,8 +33,6 @@ func TestDsPeerstore(t *testing.T) {
 func TestDsAddrBook(t *testing.T) {
 	for name, dsFactory := range dstores {
 		t.Run(name+" Cacheful", func(t *testing.T) {
-			t.Parallel()
-
 			opts := DefaultOpts()
 			opts.GCPurgeInterval = 1 * time.Second
 			opts.CacheSize = 1024
@@ -43,8 +41,6 @@ func TestDsAddrBook(t *testing.T) {
 		})
 
 		t.Run(name+" Cacheless", func(t *testing.T) {
-			t.Parallel()
-
 			opts := DefaultOpts()
 			opts.GCPurgeInterval = 1 * time.Second
 			opts.CacheSize = 0

--- a/test/addr_book_suite.go
+++ b/test/addr_book_suite.go
@@ -457,8 +457,11 @@ func testCertifiedAddresses(m pstore.AddrBook) func(*testing.T) {
 		rec4.Addrs = certifiedAddrs
 		signedRec4, err := record.Seal(rec4, priv)
 		test.AssertNilError(t, err)
-		_, err = cab.ConsumePeerRecord(signedRec4, time.Hour)
+		accepted, err = cab.ConsumePeerRecord(signedRec4, time.Hour)
 		test.AssertNilError(t, err)
+		if !accepted {
+			t.Error("expected peer record to be accepted")
+		}
 		// AssertAddressesEqual(t, certifiedAddrs, m.Addrs(id))
 		AssertAddressesEqual(t, allAddrs, m.Addrs(id))
 
@@ -475,7 +478,10 @@ func testCertifiedAddresses(m pstore.AddrBook) func(*testing.T) {
 		}
 
 		// Test that natural TTL expiration clears signed peer records
-		_, err = cab.ConsumePeerRecord(signedRec4, time.Second)
+		accepted, err = cab.ConsumePeerRecord(signedRec4, time.Second)
+		if !accepted {
+			t.Error("expected peer record to be accepted")
+		}
 		test.AssertNilError(t, err)
 		AssertAddressesEqual(t, certifiedAddrs, m.Addrs(id))
 


### PR DESCRIPTION
This fixes a flaky test on macOS where the clocks can do funny things. This ensures that we delete records when setting their TTLs to 0.