### PR TITLE
Fix test flakes

### DIFF
--- a/pstoreds/ds_test.go
+++ b/pstoreds/ds_test.go
@@ -102,17 +102,13 @@ func badgerStore(tb testing.TB) (ds.Batching, func()) {
 }
 
 func leveldbStore(tb testing.TB) (ds.Batching, func()) {
-	dataPath, err := ioutil.TempDir(os.TempDir(), "leveldb")
-	if err != nil {
-		tb.Fatal(err)
-	}
-	store, err := leveldb.NewDatastore(dataPath, nil)
+	// Intentionally test in-memory because disks suck, especially in CI.
+	store, err := leveldb.NewDatastore("", nil)
 	if err != nil {
 		tb.Fatal(err)
 	}
 	closer := func() {
 		store.Close()
-		os.RemoveAll(dataPath)
 	}
 	return store, closer
 }

--- a/pstoreds/ds_test.go
+++ b/pstoreds/ds_test.go
@@ -33,8 +33,6 @@ func TestDsPeerstore(t *testing.T) {
 func TestDsAddrBook(t *testing.T) {
 	for name, dsFactory := range dstores {
 		t.Run(name+" Cacheful", func(t *testing.T) {
-			t.Parallel()
-
 			opts := DefaultOpts()
 			opts.GCPurgeInterval = 1 * time.Second
 			opts.CacheSize = 1024
@@ -43,8 +41,6 @@ func TestDsAddrBook(t *testing.T) {
 		})
 
 		t.Run(name+" Cacheless", func(t *testing.T) {
-			t.Parallel()
-
 			opts := DefaultOpts()
 			opts.GCPurgeInterval = 1 * time.Second
 			opts.CacheSize = 0

--- a/test/addr_book_suite.go
+++ b/test/addr_book_suite.go
@@ -457,8 +457,11 @@ func testCertifiedAddresses(m pstore.AddrBook) func(*testing.T) {
 		rec4.Addrs = certifiedAddrs
 		signedRec4, err := record.Seal(rec4, priv)
 		test.AssertNilError(t, err)
-		_, err = cab.ConsumePeerRecord(signedRec4, time.Hour)
+		accepted, err = cab.ConsumePeerRecord(signedRec4, time.Hour)
 		test.AssertNilError(t, err)
+		if !accepted {
+			t.Error("expected peer record to be accepted")
+		}
 		// AssertAddressesEqual(t, certifiedAddrs, m.Addrs(id))
 		AssertAddressesEqual(t, allAddrs, m.Addrs(id))
 
@@ -475,7 +478,10 @@ func testCertifiedAddresses(m pstore.AddrBook) func(*testing.T) {
 		}
 
 		// Test that natural TTL expiration clears signed peer records
-		_, err = cab.ConsumePeerRecord(signedRec4, time.Second)
+		accepted, err = cab.ConsumePeerRecord(signedRec4, time.Second)
+		if !accepted {
+			t.Error("expected peer record to be accepted")
+		}
 		test.AssertNilError(t, err)
 		AssertAddressesEqual(t, certifiedAddrs, m.Addrs(id))
 

--- a/test/addr_book_suite.go
+++ b/test/addr_book_suite.go
@@ -119,8 +119,8 @@ func testAddAddress(ab pstore.AddrBook) func(*testing.T) {
 
 			ab.AddAddrs(id, addrs, 4*time.Second)
 			// 4 seconds left
-			time.Sleep(3 * time.Second)
-			// 1 second left
+			time.Sleep(2 * time.Second)
+			// 2 second left
 			ab.AddAddrs(id, addrs, 3*time.Second)
 			// 3 seconds left
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
1. Don't run datastore tests in parallel.
2. Avoid writing to disk, just test in-memory.
3. Add some additional assertions to make debugging errors easier.