### PR TITLE
remove all calls to peer.ID.Validate

### DIFF
--- a/pstoreds/addr_book.go
+++ b/pstoreds/addr_book.go
@@ -207,9 +207,6 @@ func (ab *dsAddrBook) Close() error {
 //
 // If the cache argument is true, the record is inserted in the cache when loaded from the datastore.
 func (ab *dsAddrBook) loadRecord(id peer.ID, cache bool, update bool) (pr *addrsRecord, err error) {
-	if err := id.Validate(); err != nil {
-		return nil, err
-	}
 	if e, ok := ab.cache.Get(id); ok {
 		pr = e.(*addrsRecord)
 		pr.Lock()
@@ -438,11 +435,6 @@ func (ab *dsAddrBook) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Multi
 
 // ClearAddrs will delete all known addresses for a peer ID.
 func (ab *dsAddrBook) ClearAddrs(p peer.ID) {
-	if err := p.Validate(); err != nil {
-		// nothing to do
-		return
-	}
-
 	ab.cache.Remove(p)
 
 	key := addrBookBase.ChildString(b32.RawStdEncoding.EncodeToString([]byte(p)))

--- a/pstoreds/metadata.go
+++ b/pstoreds/metadata.go
@@ -41,9 +41,6 @@ func NewPeerMetadata(_ context.Context, store ds.Datastore, _ Options) (*dsPeerM
 }
 
 func (pm *dsPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
 	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).ChildString(key)
 	value, err := pm.ds.Get(context.TODO(), k)
 	if err != nil {
@@ -61,9 +58,6 @@ func (pm *dsPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
 }
 
 func (pm *dsPeerMetadata) Put(p peer.ID, key string, val interface{}) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
 	k := pmBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p))).ChildString(key)
 	var buf pool.Buffer
 	if err := gob.NewEncoder(&buf).Encode(&val); err != nil {

--- a/pstoreds/protobook.go
+++ b/pstoreds/protobook.go
@@ -60,9 +60,6 @@ func NewProtoBook(meta pstore.PeerMetadata, opts ...ProtoBookOption) (*dsProtoBo
 }
 
 func (pb *dsProtoBook) SetProtocols(p peer.ID, protos ...string) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
 	if len(protos) > pb.maxProtos {
 		return errTooManyProtocols
 	}
@@ -80,10 +77,6 @@ func (pb *dsProtoBook) SetProtocols(p peer.ID, protos ...string) error {
 }
 
 func (pb *dsProtoBook) AddProtocols(p peer.ID, protos ...string) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
-
 	s := pb.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -104,10 +97,6 @@ func (pb *dsProtoBook) AddProtocols(p peer.ID, protos ...string) error {
 }
 
 func (pb *dsProtoBook) GetProtocols(p peer.ID) ([]string, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
-
 	s := pb.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -126,10 +115,6 @@ func (pb *dsProtoBook) GetProtocols(p peer.ID) ([]string, error) {
 }
 
 func (pb *dsProtoBook) SupportsProtocols(p peer.ID, protos ...string) ([]string, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
-
 	s := pb.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -150,10 +135,6 @@ func (pb *dsProtoBook) SupportsProtocols(p peer.ID, protos ...string) ([]string,
 }
 
 func (pb *dsProtoBook) FirstSupportedProtocol(p peer.ID, protos ...string) (string, error) {
-	if err := p.Validate(); err != nil {
-		return "", err
-	}
-
 	s := pb.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -172,10 +153,6 @@ func (pb *dsProtoBook) FirstSupportedProtocol(p peer.ID, protos ...string) (stri
 }
 
 func (pb *dsProtoBook) RemoveProtocols(p peer.ID, protos ...string) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
-
 	s := pb.segments.get(p)
 	s.Lock()
 	defer s.Unlock()

--- a/pstoremem/addr_book.go
+++ b/pstoremem/addr_book.go
@@ -191,11 +191,6 @@ func (mab *memoryAddrBook) ConsumePeerRecord(recordEnvelope *record.Envelope, tt
 }
 
 func (mab *memoryAddrBook) addAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration) {
-	if err := p.Validate(); err != nil {
-		log.Warnw("tried to set addrs for invalid peer ID", "peer", p, "error", err)
-		return
-	}
-
 	s := mab.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -244,22 +239,12 @@ func (mab *memoryAddrBook) addAddrsUnlocked(s *addrSegment, p peer.ID, addrs []m
 
 // SetAddr calls mgr.SetAddrs(p, addr, ttl)
 func (mab *memoryAddrBook) SetAddr(p peer.ID, addr ma.Multiaddr, ttl time.Duration) {
-	if err := p.Validate(); err != nil {
-		log.Warnw("tried to set addrs for invalid peer ID", "peer", p, "error", err)
-		return
-	}
-
 	mab.SetAddrs(p, []ma.Multiaddr{addr}, ttl)
 }
 
 // SetAddrs sets the ttl on addresses. This clears any TTL there previously.
 // This is used when we receive the best estimate of the validity of an address.
 func (mab *memoryAddrBook) SetAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration) {
-	if err := p.Validate(); err != nil {
-		log.Warnw("tried to set addrs for invalid peer ID", "peer", p, "error", err)
-		return
-	}
-
 	s := mab.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -292,11 +277,6 @@ func (mab *memoryAddrBook) SetAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Du
 // UpdateAddrs updates the addresses associated with the given peer that have
 // the given oldTTL to have the given newTTL.
 func (mab *memoryAddrBook) UpdateAddrs(p peer.ID, oldTTL time.Duration, newTTL time.Duration) {
-	if err := p.Validate(); err != nil {
-		log.Warnw("tried to set addrs for invalid peer ID", "peer", p, "error", err)
-		return
-	}
-
 	s := mab.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -321,11 +301,6 @@ func (mab *memoryAddrBook) UpdateAddrs(p peer.ID, oldTTL time.Duration, newTTL t
 
 // Addrs returns all known (and valid) addresses for a given peer
 func (mab *memoryAddrBook) Addrs(p peer.ID) []ma.Multiaddr {
-	if err := p.Validate(); err != nil {
-		// invalid peer ID = no addrs
-		return nil
-	}
-
 	s := mab.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -352,11 +327,6 @@ func validAddrs(amap map[string]*expiringAddr) []ma.Multiaddr {
 // given peer id, if one exists.
 // Returns nil if no signed PeerRecord exists for the peer.
 func (mab *memoryAddrBook) GetPeerRecord(p peer.ID) *record.Envelope {
-	if err := p.Validate(); err != nil {
-		// invalid peer ID = no addrs
-		return nil
-	}
-
 	s := mab.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -377,11 +347,6 @@ func (mab *memoryAddrBook) GetPeerRecord(p peer.ID) *record.Envelope {
 
 // ClearAddrs removes all previously stored addresses
 func (mab *memoryAddrBook) ClearAddrs(p peer.ID) {
-	if err := p.Validate(); err != nil {
-		// nothing to clear
-		return
-	}
-
 	s := mab.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -393,13 +358,6 @@ func (mab *memoryAddrBook) ClearAddrs(p peer.ID) {
 // AddrStream returns a channel on which all new addresses discovered for a
 // given peer ID will be published.
 func (mab *memoryAddrBook) AddrStream(ctx context.Context, p peer.ID) <-chan ma.Multiaddr {
-	if err := p.Validate(); err != nil {
-		log.Warnw("tried to set addrs for invalid peer ID", "peer", p, "error", err)
-		ch := make(chan ma.Multiaddr)
-		close(ch)
-		return ch
-	}
-
 	s := mab.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()

--- a/pstoremem/metadata.go
+++ b/pstoremem/metadata.go
@@ -22,9 +22,6 @@ func NewPeerMetadata() *memoryPeerMetadata {
 }
 
 func (ps *memoryPeerMetadata) Put(p peer.ID, key string, val interface{}) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
 	ps.dslock.Lock()
 	defer ps.dslock.Unlock()
 	m, ok := ps.ds[p]
@@ -37,9 +34,6 @@ func (ps *memoryPeerMetadata) Put(p peer.ID, key string, val interface{}) error 
 }
 
 func (ps *memoryPeerMetadata) Get(p peer.ID, key string) (interface{}, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
 	ps.dslock.RLock()
 	defer ps.dslock.RUnlock()
 	m, ok := ps.ds[p]

--- a/pstoremem/protobook.go
+++ b/pstoremem/protobook.go
@@ -89,9 +89,6 @@ func (pb *memoryProtoBook) internProtocol(proto string) string {
 }
 
 func (pb *memoryProtoBook) SetProtocols(p peer.ID, protos ...string) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
 	if len(protos) > pb.maxProtos {
 		return errTooManyProtocols
 	}
@@ -110,10 +107,6 @@ func (pb *memoryProtoBook) SetProtocols(p peer.ID, protos ...string) error {
 }
 
 func (pb *memoryProtoBook) AddProtocols(p peer.ID, protos ...string) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
-
 	s := pb.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -134,10 +127,6 @@ func (pb *memoryProtoBook) AddProtocols(p peer.ID, protos ...string) error {
 }
 
 func (pb *memoryProtoBook) GetProtocols(p peer.ID) ([]string, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
-
 	s := pb.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -151,10 +140,6 @@ func (pb *memoryProtoBook) GetProtocols(p peer.ID) ([]string, error) {
 }
 
 func (pb *memoryProtoBook) RemoveProtocols(p peer.ID, protos ...string) error {
-	if err := p.Validate(); err != nil {
-		return err
-	}
-
 	s := pb.segments.get(p)
 	s.Lock()
 	defer s.Unlock()
@@ -172,10 +157,6 @@ func (pb *memoryProtoBook) RemoveProtocols(p peer.ID, protos ...string) error {
 }
 
 func (pb *memoryProtoBook) SupportsProtocols(p peer.ID, protos ...string) ([]string, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
-
 	s := pb.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()
@@ -191,10 +172,6 @@ func (pb *memoryProtoBook) SupportsProtocols(p peer.ID, protos ...string) ([]str
 }
 
 func (pb *memoryProtoBook) FirstSupportedProtocol(p peer.ID, protos ...string) (string, error) {
-	if err := p.Validate(); err != nil {
-		return "", err
-	}
-
 	s := pb.segments.get(p)
 	s.RLock()
 	defer s.RUnlock()

--- a/test/peerstore_suite.go
+++ b/test/peerstore_suite.go
@@ -268,23 +268,6 @@ func testPeerstoreProtoStore(ps pstore.Peerstore) func(t *testing.T) {
 			}
 		})
 
-		t.Run("bad peer ID", func(t *testing.T) {
-			badp := peer.ID("")
-			require.Error(t, ps.AddProtocols(badp, "proto"), "expected error when using a bad peer ID")
-
-			if _, err := ps.GetProtocols(badp); err == nil || err == pstore.ErrNotFound {
-				t.Fatal("expected error when using a bad peer ID")
-			}
-
-			if _, err := ps.SupportsProtocols(badp, "q", "w", "a", "y", "b"); err == nil || err == pstore.ErrNotFound {
-				t.Fatal("expected error when using a bad peer ID")
-			}
-
-			if err := ps.RemoveProtocols(badp); err == nil || err == pstore.ErrNotFound {
-				t.Fatal("expected error when using a bad peer ID")
-			}
-		})
-
 		t.Run("removing peer", func(t *testing.T) {
 			p := peer.ID("foobar")
 			protos := []string{"a", "b"}
@@ -328,10 +311,6 @@ func testBasicPeerstore(ps pstore.Peerstore) func(t *testing.T) {
 		if !pinfo.Addrs[0].Equal(addrs[0]) {
 			t.Fatal("stored wrong address")
 		}
-
-		// should fail silently...
-		ps.AddAddrs("", addrs, pstore.PermanentAddrTTL)
-		ps.Addrs("")
 	}
 }
 
@@ -358,13 +337,6 @@ func testMetadata(ps pstore.Peerstore) func(t *testing.T) {
 				v, err = ps.Get(p, "bar")
 				require.NoError(t, err)
 				require.Equal(t, v, 1)
-			}
-		})
-
-		t.Run("bad peer ID", func(t *testing.T) {
-			require.Error(t, ps.Put("", "foobar", "thing"), "expected error for bad peer ID")
-			if _, err := ps.Get("", "foobar"); err == nil || err == pstore.ErrNotFound {
-				t.Fatalf("expected error for bad peer ID")
 			}
 		})
 


### PR DESCRIPTION
Fixes #182.

To check if this has any unintended consequences, I build a go-ipfs binary where any failed call to `peer.ID.Validate` would panic. I ran it for a few hours without any problems.