### PR TITLE
feat: Use a clock interface in pstoreds as well

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 retract v0.2.9 // Contains backwards-incompatible changes. Use v0.3.0 instead.
 
 require (
+	github.com/benbjohnson/clock v1.3.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-datastore v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=

--- a/pstoreds/ds_test.go
+++ b/pstoreds/ds_test.go
@@ -15,6 +15,8 @@ import (
 
 	pstore "github.com/libp2p/go-libp2p-core/peerstore"
 	pt "github.com/libp2p/go-libp2p-peerstore/test"
+
+	mockClock "github.com/benbjohnson/clock"
 )
 
 type datastoreFactory func(tb testing.TB) (ds.Batching, func())
@@ -50,16 +52,20 @@ func TestDsAddrBook(t *testing.T) {
 			opts := DefaultOpts()
 			opts.GCPurgeInterval = 1 * time.Second
 			opts.CacheSize = 1024
+			clk := mockClock.NewMock()
+			opts.Clock = clk
 
-			pt.TestAddrBook(t, addressBookFactory(t, dsFactory, opts))
+			pt.TestAddrBook(t, addressBookFactory(t, dsFactory, opts), clk)
 		})
 
 		t.Run(name+" Cacheless", func(t *testing.T) {
 			opts := DefaultOpts()
 			opts.GCPurgeInterval = 1 * time.Second
 			opts.CacheSize = 0
+			clk := mockClock.NewMock()
+			opts.Clock = clk
 
-			pt.TestAddrBook(t, addressBookFactory(t, dsFactory, opts))
+			pt.TestAddrBook(t, addressBookFactory(t, dsFactory, opts), clk)
 		})
 	}
 }

--- a/pstoreds/peerstore.go
+++ b/pstoreds/peerstore.go
@@ -34,6 +34,8 @@ type Options struct {
 	// Initial delay before GC processes start. Intended to give the system breathing room to fully boot
 	// before starting GC.
 	GCInitialDelay time.Duration
+
+	Clock clock
 }
 
 // DefaultOpts returns the default options for a persistent peerstore, with the full-purge GC algorithm:
@@ -50,6 +52,7 @@ func DefaultOpts() Options {
 		GCPurgeInterval:     2 * time.Hour,
 		GCLookaheadInterval: 0,
 		GCInitialDelay:      60 * time.Second,
+		Clock:               realclock{},
 	}
 }
 

--- a/pstoremem/inmem_test.go
+++ b/pstoremem/inmem_test.go
@@ -7,6 +7,7 @@ import (
 
 	pstore "github.com/libp2p/go-libp2p-core/peerstore"
 
+	mockClock "github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -43,11 +44,12 @@ func TestPeerstoreProtoStoreLimits(t *testing.T) {
 }
 
 func TestInMemoryAddrBook(t *testing.T) {
+	clk := mockClock.NewMock()
 	pt.TestAddrBook(t, func() (pstore.AddrBook, func()) {
-		ps, err := NewPeerstore()
+		ps, err := NewPeerstore(WithClock(clk))
 		require.NoError(t, err)
 		return ps, func() { ps.Close() }
-	})
+	}, clk)
 }
 
 func TestInMemoryKeyBook(t *testing.T) {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.0"
+  "version": "v0.7.0"
 }


### PR DESCRIPTION
Continues the work from https://github.com/libp2p/go-libp2p-peerstore/pull/199 to do the same thing in pstoreds.

This also updates the tests. On my machine, tests finish in 5s compared to 46s before this change.
